### PR TITLE
T3.1 — Чистые функции compute_current_uptime и compute_sla

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,6 @@ changelog_file = "CHANGELOG.md"
 allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test"]
 minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]
+
+[tool.pytest.ini_options]
+pythonpath = ["rest_assured"]

--- a/rest_assured/src/services/metrics.py
+++ b/rest_assured/src/services/metrics.py
@@ -1,0 +1,60 @@
+from datetime import datetime
+from typing import Protocol
+
+
+class CheckResult(Protocol):
+    checked_at: datetime
+    is_up: bool
+
+
+def compute_current_uptime(checks: list[CheckResult]) -> int:
+    """Текущий uptime в секундах от последнего фейла до последней проверки."""
+    if not checks:
+        return 0
+
+    current_uptime = 0
+    previous_check = None
+
+    for check in checks:
+        if not check.is_up:
+            current_uptime = 0
+            previous_check = check
+            continue
+
+        if previous_check is not None and previous_check.is_up:
+            current_uptime += int(
+                (check.checked_at - previous_check.checked_at).total_seconds()
+            )
+
+        previous_check = check
+
+    return current_uptime
+
+
+def compute_sla(checks: list[CheckResult]) -> float:
+    """SLA = total_uptime / total_monitoring_time, в долях [0.0..1.0]."""
+    if not checks:
+        return 0.0
+
+    if len(checks) == 1:
+        return 1.0 if checks[0].is_up else 0.0
+
+    total_monitoring_time = int(
+        (checks[-1].checked_at - checks[0].checked_at).total_seconds()
+    )
+
+    if total_monitoring_time <= 0:
+        return 0.0
+
+    total_uptime = 0
+    previous_check = checks[0]
+
+    for check in checks[1:]:
+        if previous_check.is_up and check.is_up:
+            total_uptime += int(
+                (check.checked_at - previous_check.checked_at).total_seconds()
+            )
+
+        previous_check = check
+
+    return total_uptime / total_monitoring_time

--- a/rest_assured/tests/services/test_metrics.py
+++ b/rest_assured/tests/services/test_metrics.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from src.services.metrics import compute_current_uptime, compute_sla
+
+
+@dataclass
+class FakeCheckResult:
+    checked_at: datetime
+    is_up: bool
+
+
+def make_check(base: datetime, seconds: int, is_up: bool) -> FakeCheckResult:
+    return FakeCheckResult(
+        checked_at=base + timedelta(seconds=seconds),
+        is_up=is_up,
+    )
+
+
+def test_sber_example() -> None:
+    base = datetime(2026, 1, 1, 16, 1, 40)
+
+    checks = [
+        make_check(base, 0, False),
+        make_check(base, 10, True),
+        make_check(base, 20, True),
+        make_check(base, 30, True),
+        make_check(base, 40, False),
+        make_check(base, 50, True),
+        make_check(base, 60, True),
+    ]
+
+    assert compute_current_uptime(checks) == 10
+    assert compute_sla(checks) == 0.5
+
+
+def test_empty_list() -> None:
+    assert compute_current_uptime([]) == 0
+    assert compute_sla([]) == 0.0
+
+
+def test_all_up() -> None:
+    base = datetime(2026, 1, 1, 16, 0, 0)
+
+    checks = [
+        make_check(base, 0, True),
+        make_check(base, 10, True),
+        make_check(base, 20, True),
+        make_check(base, 30, True),
+        make_check(base, 40, True),
+    ]
+
+    assert compute_current_uptime(checks) == 40
+    assert compute_sla(checks) == 1.0
+
+
+def test_all_down() -> None:
+    base = datetime(2026, 1, 1, 16, 0, 0)
+
+    checks = [
+        make_check(base, 0, False),
+        make_check(base, 10, False),
+        make_check(base, 20, False),
+    ]
+
+    assert compute_current_uptime(checks) == 0
+    assert compute_sla(checks) == 0.0
+
+
+def test_single_up() -> None:
+    base = datetime(2026, 1, 1, 16, 0, 0)
+
+    checks = [make_check(base, 0, True)]
+
+    assert compute_current_uptime(checks) == 0
+    assert compute_sla(checks) == 1.0


### PR DESCRIPTION
Description:
Closes #44

Что сделано:
- добавлены чистые функции compute_current_uptime и compute_sla
- compute_current_uptime считает текущую серию успешных проверок
- compute_sla считает общий uptime / total monitoring time
- добавлены unit-тесты на пример из пояснения и edge cases
- добавлена настройка pytest pythonpath для запуска тестов из корня проекта

Проверка:
pytest rest_assured/tests/services/test_metrics.py -v

Результат:
5 passed