### PR TITLE
T4.3 — Incident and NotificationLog models

### DIFF
--- a/rest_assured/integrational_tests/conftest.py
+++ b/rest_assured/integrational_tests/conftest.py
@@ -38,7 +38,7 @@ def _bootstrap_db() -> Generator[None, Any, None]:
 async def postgres_connection(_bootstrap_db) -> AsyncSession:
     session = get_session()
     from sqlalchemy import text
-    await session.exec(text("TRUNCATE TABLE check_results, services RESTART IDENTITY CASCADE"))
+    await session.exec(text("TRUNCATE TABLE check_results, services, incidents, notification_log RESTART IDENTITY CASCADE"))
     await session.commit()
     try:
         yield session

--- a/rest_assured/integrational_tests/conftest.py
+++ b/rest_assured/integrational_tests/conftest.py
@@ -38,7 +38,12 @@ def _bootstrap_db() -> Generator[None, Any, None]:
 async def postgres_connection(_bootstrap_db) -> AsyncSession:
     session = get_session()
     from sqlalchemy import text
-    await session.exec(text("TRUNCATE TABLE check_results, services, incidents, notification_log RESTART IDENTITY CASCADE"))
+    await session.exec(
+        text(
+            "TRUNCATE TABLE check_results, services, "
+            "incidents, notification_log RESTART IDENTITY CASCADE"
+        )
+    )
     await session.commit()
     try:
         yield session

--- a/rest_assured/integrational_tests/test_incidents.py
+++ b/rest_assured/integrational_tests/test_incidents.py
@@ -1,0 +1,96 @@
+"""Интеграционные тесты моделей Incident и NotificationLog."""
+from datetime import datetime, timezone
+import pytest
+from sqlalchemy.exc import IntegrityError
+from rest_assured.src.models.incidents import Incident
+from rest_assured.src.models.notifications import NotificationLog
+from rest_assured.src.models.services import Service
+
+@pytest.mark.asyncio
+async def test_create_incident(postgres_connection):
+    s = Service(name="svc1", url="http://example.com", interval_ms=1000)
+    postgres_connection.add(s)
+    await postgres_connection.commit()
+    await postgres_connection.refresh(s)
+
+    now = datetime.now(timezone.utc)
+    incident = Incident(service_id=s.id, opened_at=now, last_error="test error")
+    postgres_connection.add(incident)
+    await postgres_connection.commit()
+    await postgres_connection.refresh(incident)
+
+    assert incident.id is not None
+    assert incident.service_id == s.id
+    assert incident.closed_at is None
+    assert incident.last_error == "test error"
+    assert incident.sla_breach is False
+
+@pytest.mark.asyncio
+async def test_unique_open_incident_per_service(postgres_connection):
+    s = Service(name="svc2", url="http://example.com", interval_ms=1000)
+    postgres_connection.add(s)
+    await postgres_connection.commit()
+    await postgres_connection.refresh(s)
+
+    now = datetime.now(timezone.utc)
+    inc1 = Incident(service_id=s.id, opened_at=now)
+    postgres_connection.add(inc1)
+    await postgres_connection.commit()
+
+    inc2 = Incident(service_id=s.id, opened_at=datetime.now(timezone.utc))
+    postgres_connection.add(inc2)
+    with pytest.raises(IntegrityError):
+        await postgres_connection.commit()
+    await postgres_connection.rollback()
+
+@pytest.mark.asyncio
+async def test_reopen_after_close(postgres_connection):
+    s = Service(name="svc3", url="http://example.com", interval_ms=1000)
+    postgres_connection.add(s)
+    await postgres_connection.commit()
+    await postgres_connection.refresh(s)
+
+    now = datetime.now(timezone.utc)
+    inc1 = Incident(service_id=s.id, opened_at=now)
+    postgres_connection.add(inc1)
+    await postgres_connection.commit()
+    await postgres_connection.refresh(inc1)
+
+    # закрываем
+    inc1.closed_at = datetime.now(timezone.utc)
+    await postgres_connection.commit()
+
+    # теперь можно создать новый открытый
+    inc2 = Incident(service_id=s.id, opened_at=datetime.now(timezone.utc))
+    postgres_connection.add(inc2)
+    await postgres_connection.commit()
+    assert inc2.id is not None
+
+@pytest.mark.asyncio
+async def test_notification_log_creation(postgres_connection):
+    s = Service(name="svc4", url="http://example.com", interval_ms=1000)
+    postgres_connection.add(s)
+    await postgres_connection.commit()
+    await postgres_connection.refresh(s)
+
+    incident = Incident(service_id=s.id, opened_at=datetime.now(timezone.utc))
+    postgres_connection.add(incident)
+    await postgres_connection.commit()
+    await postgres_connection.refresh(incident)
+
+    log = NotificationLog(
+        incident_id=incident.id,
+        service_id=s.id,
+        kind="incident_opened",
+        sent_at=datetime.now(timezone.utc),
+        recipients="admin@example.com",
+        subject="Incident opened",
+        error=None,
+    )
+    postgres_connection.add(log)
+    await postgres_connection.commit()
+    await postgres_connection.refresh(log)
+
+    assert log.id is not None
+    assert log.kind == "incident_opened"
+    assert log.error is None

--- a/rest_assured/integrational_tests/test_incidents.py
+++ b/rest_assured/integrational_tests/test_incidents.py
@@ -11,84 +11,92 @@ from rest_assured.src.models.services import Service
 
 @pytest.mark.asyncio
 async def test_create_incident(postgres_connection):
-    s = Service(name="svc1", url="http://example.com", interval_ms=1000)
-    postgres_connection.add(s)
+    service = Service(name="svc1", url="http://example.com", interval_ms=1000)
+    postgres_connection.add(service)
     await postgres_connection.commit()
-    await postgres_connection.refresh(s)
+    await postgres_connection.refresh(service)
 
     now = datetime.now(timezone.utc)
-    incident = Incident(service_id=s.id, opened_at=now, last_error="test error")
+    incident = Incident(
+        service_id=service.id, opened_at=now, last_error="test error",
+    )
     postgres_connection.add(incident)
     await postgres_connection.commit()
     await postgres_connection.refresh(incident)
 
     assert incident.id is not None
-    assert incident.service_id == s.id
+    assert incident.service_id == service.id
     assert incident.closed_at is None
     assert incident.last_error == "test error"
     assert incident.sla_breach is False
 
+
 @pytest.mark.asyncio
 async def test_unique_open_incident_per_service(postgres_connection):
-    s = Service(name="svc2", url="http://example.com", interval_ms=1000)
-    postgres_connection.add(s)
+    service = Service(name="svc2", url="http://example.com", interval_ms=1000)
+    postgres_connection.add(service)
     await postgres_connection.commit()
-    await postgres_connection.refresh(s)
+    await postgres_connection.refresh(service)
 
-    now = datetime.now(timezone.utc)
-    inc1 = Incident(service_id=s.id, opened_at=now)
+    inc1 = Incident(service_id=service.id, opened_at=datetime.now(timezone.utc))
     postgres_connection.add(inc1)
     await postgres_connection.commit()
 
-    inc2 = Incident(service_id=s.id, opened_at=datetime.now(timezone.utc))
+    inc2 = Incident(
+        service_id=service.id, opened_at=datetime.now(timezone.utc),
+    )
     postgres_connection.add(inc2)
     with pytest.raises(IntegrityError):
         await postgres_connection.commit()
     await postgres_connection.rollback()
 
+
 @pytest.mark.asyncio
 async def test_reopen_after_close(postgres_connection):
-    s = Service(name="svc3", url="http://example.com", interval_ms=1000)
-    postgres_connection.add(s)
+    service = Service(name="svc3", url="http://example.com", interval_ms=1000)
+    postgres_connection.add(service)
     await postgres_connection.commit()
-    await postgres_connection.refresh(s)
+    await postgres_connection.refresh(service)
 
-    now = datetime.now(timezone.utc)
-    inc1 = Incident(service_id=s.id, opened_at=now)
+    inc1 = Incident(
+        service_id=service.id, opened_at=datetime.now(timezone.utc),
+    )
     postgres_connection.add(inc1)
     await postgres_connection.commit()
     await postgres_connection.refresh(inc1)
 
-    # закрываем
     inc1.closed_at = datetime.now(timezone.utc)
     await postgres_connection.commit()
 
-    # теперь можно создать новый открытый
-    inc2 = Incident(service_id=s.id, opened_at=datetime.now(timezone.utc))
+    inc2 = Incident(
+        service_id=service.id, opened_at=datetime.now(timezone.utc),
+    )
     postgres_connection.add(inc2)
     await postgres_connection.commit()
     assert inc2.id is not None
 
+
 @pytest.mark.asyncio
 async def test_notification_log_creation(postgres_connection):
-    s = Service(name="svc4", url="http://example.com", interval_ms=1000)
-    postgres_connection.add(s)
+    service = Service(name="svc4", url="http://example.com", interval_ms=1000)
+    postgres_connection.add(service)
     await postgres_connection.commit()
-    await postgres_connection.refresh(s)
+    await postgres_connection.refresh(service)
 
-    incident = Incident(service_id=s.id, opened_at=datetime.now(timezone.utc))
+    incident = Incident(
+        service_id=service.id, opened_at=datetime.now(timezone.utc),
+    )
     postgres_connection.add(incident)
     await postgres_connection.commit()
     await postgres_connection.refresh(incident)
 
     log = NotificationLog(
         incident_id=incident.id,
-        service_id=s.id,
+        service_id=service.id,
         kind="incident_opened",
         sent_at=datetime.now(timezone.utc),
         recipients="admin@example.com",
         subject="Incident opened",
-        error=None,
     )
     postgres_connection.add(log)
     await postgres_connection.commit()
@@ -97,3 +105,60 @@ async def test_notification_log_creation(postgres_connection):
     assert log.id is not None
     assert log.kind == "incident_opened"
     assert log.error is None
+
+
+@pytest.mark.asyncio
+async def test_notification_log_without_incident(postgres_connection):
+    """NotificationLog может существовать без привязки к инциденту."""
+    service = Service(name="svc5", url="http://example.com", interval_ms=1000)
+    postgres_connection.add(service)
+    await postgres_connection.commit()
+    await postgres_connection.refresh(service)
+
+    log = NotificationLog(
+        incident_id=None,
+        service_id=service.id,
+        kind="manual_alert",
+        sent_at=datetime.now(timezone.utc),
+        recipients="ops@example.com",
+        subject="Manual alert",
+    )
+    postgres_connection.add(log)
+    await postgres_connection.commit()
+    await postgres_connection.refresh(log)
+
+    assert log.id is not None
+    assert log.incident_id is None
+
+
+@pytest.mark.asyncio
+async def test_incident_sla_breach_flag(postgres_connection):
+    """Проверяет установку флага sla_breach."""
+    service = Service(name="svc6", url="http://example.com", interval_ms=1000)
+    postgres_connection.add(service)
+    await postgres_connection.commit()
+    await postgres_connection.refresh(service)
+
+    incident = Incident(
+        service_id=service.id,
+        opened_at=datetime.now(timezone.utc),
+        sla_breach=True,
+    )
+    postgres_connection.add(incident)
+    await postgres_connection.commit()
+    await postgres_connection.refresh(incident)
+
+    assert incident.sla_breach is True
+
+
+@pytest.mark.asyncio
+async def test_incident_fk_prevents_orphan(postgres_connection):
+    """FK на несуществующий service_id должен бросать IntegrityError."""
+    incident = Incident(
+        service_id=999999,
+        opened_at=datetime.now(timezone.utc),
+    )
+    postgres_connection.add(incident)
+    with pytest.raises(IntegrityError):
+        await postgres_connection.commit()
+    await postgres_connection.rollback()

--- a/rest_assured/integrational_tests/test_incidents.py
+++ b/rest_assured/integrational_tests/test_incidents.py
@@ -1,10 +1,13 @@
 """Интеграционные тесты моделей Incident и NotificationLog."""
 from datetime import datetime, timezone
+
 import pytest
 from sqlalchemy.exc import IntegrityError
+
 from rest_assured.src.models.incidents import Incident
 from rest_assured.src.models.notifications import NotificationLog
 from rest_assured.src.models.services import Service
+
 
 @pytest.mark.asyncio
 async def test_create_incident(postgres_connection):

--- a/rest_assured/src/alembic/env.py
+++ b/rest_assured/src/alembic/env.py
@@ -8,9 +8,12 @@ from alembic import context
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from rest_assured.src.configs.app.main import settings
-from rest_assured.src.models import CheckResult, Service  # noqa: F401
+from rest_assured.src.models import CheckResult, Service, Incident, NotificationLog  # noqa: F401
 
-target_metadata = [Service.metadata, CheckResult.metadata]
+target_metadata = [Service.metadata,
+    CheckResult.metadata,
+    Incident.metadata,
+    NotificationLog.metadata,]
 
 
 def get_url():

--- a/rest_assured/src/alembic/env.py
+++ b/rest_assured/src/alembic/env.py
@@ -8,7 +8,7 @@ from alembic import context
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from rest_assured.src.configs.app.main import settings
-from rest_assured.src.models import CheckResult, Service, Incident, NotificationLog  # noqa: F401
+from rest_assured.src.models import CheckResult, Incident, NotificationLog, Service  # noqa: F401
 
 target_metadata = [Service.metadata,
     CheckResult.metadata,

--- a/rest_assured/src/alembic/env.py
+++ b/rest_assured/src/alembic/env.py
@@ -10,10 +10,12 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from rest_assured.src.configs.app.main import settings
 from rest_assured.src.models import CheckResult, Incident, NotificationLog, Service  # noqa: F401
 
-target_metadata = [Service.metadata,
+target_metadata = [
+    Service.metadata,
     CheckResult.metadata,
     Incident.metadata,
-    NotificationLog.metadata,]
+    NotificationLog.metadata,
+]
 
 
 def get_url():

--- a/rest_assured/src/alembic/versions/002_incidents_notifications.py
+++ b/rest_assured/src/alembic/versions/002_incidents_notifications.py
@@ -5,6 +5,7 @@ Revises: 001
 Create Date: ...
 """
 from typing import Sequence, Union
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/rest_assured/src/alembic/versions/002_incidents_notifications.py
+++ b/rest_assured/src/alembic/versions/002_incidents_notifications.py
@@ -1,0 +1,51 @@
+"""add incidents and notification_log tables
+
+Revision ID: 002
+Revises: 001
+Create Date: ...
+"""
+from typing import Sequence, Union
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "002"
+down_revision: Union[str, None] = "001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade():
+    op.create_table(
+        "incidents",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("service_id", sa.Integer(), sa.ForeignKey("services.id"), nullable=False),
+        sa.Column("opened_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error", sa.String(), nullable=True),
+        sa.Column("sla_breach", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("service_id", name="uq_incidents_service_open",
+                            postgresql_where=sa.text("closed_at IS NULL")),
+    )
+    op.create_index("ix_incidents_service_id", "incidents", ["service_id"])
+    op.create_index("ix_incidents_closed_at", "incidents", ["closed_at"])
+
+    op.create_table(
+        "notification_log",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("incident_id", sa.Integer(), sa.ForeignKey("incidents.id"), nullable=True),
+        sa.Column("service_id", sa.Integer(), sa.ForeignKey("services.id"), nullable=False),
+        sa.Column("kind", sa.String(length=50), nullable=False),
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("recipients", sa.String(length=500), nullable=False),
+        sa.Column("subject", sa.String(length=500), nullable=False),
+        sa.Column("error", sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_notification_log_incident_id", "notification_log", ["incident_id"])
+    op.create_index("ix_notification_log_service_id", "notification_log", ["service_id"])
+    op.create_index("ix_notification_log_kind_sent", "notification_log",
+                    ["service_id", "kind", sa.text("sent_at DESC")])
+
+def downgrade():
+    op.drop_table("notification_log")
+    op.drop_table("incidents")

--- a/rest_assured/src/alembic/versions/002_incidents_notifications.py
+++ b/rest_assured/src/alembic/versions/002_incidents_notifications.py
@@ -2,7 +2,7 @@
 
 Revision ID: 002
 Revises: 001
-Create Date: ...
+Create Date: 2026-05-12 23:57:15.000000
 """
 from typing import Sequence, Union
 
@@ -14,39 +14,79 @@ down_revision: Union[str, None] = "001"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
+
 def upgrade():
     op.create_table(
         "incidents",
         sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("service_id", sa.Integer(), sa.ForeignKey("services.id"), nullable=False),
+        sa.Column(
+            "service_id",
+            sa.Integer(),
+            sa.ForeignKey("services.id"),
+            nullable=False,
+        ),
         sa.Column("opened_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("closed_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("last_error", sa.String(), nullable=True),
-        sa.Column("sla_breach", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("last_error", sa.String(length=500), nullable=True),
+        sa.Column(
+            "sla_breach",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("service_id", name="uq_incidents_service_open",
-                            postgresql_where=sa.text("closed_at IS NULL")),
     )
     op.create_index("ix_incidents_service_id", "incidents", ["service_id"])
     op.create_index("ix_incidents_closed_at", "incidents", ["closed_at"])
+    op.create_index(
+        "uq_incidents_service_open",
+        "incidents",
+        ["service_id"],
+        unique=True,
+        postgresql_where=sa.text("closed_at IS NULL"),
+    )
 
     op.create_table(
         "notification_log",
         sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("incident_id", sa.Integer(), sa.ForeignKey("incidents.id"), nullable=True),
-        sa.Column("service_id", sa.Integer(), sa.ForeignKey("services.id"), nullable=False),
+        sa.Column(
+            "incident_id",
+            sa.Integer(),
+            sa.ForeignKey("incidents.id"),
+            nullable=True,
+        ),
+        sa.Column(
+            "service_id",
+            sa.Integer(),
+            sa.ForeignKey("services.id"),
+            nullable=False,
+        ),
         sa.Column("kind", sa.String(length=50), nullable=False),
         sa.Column("sent_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("recipients", sa.String(length=500), nullable=False),
         sa.Column("subject", sa.String(length=500), nullable=False),
-        sa.Column("error", sa.String(), nullable=True),
+        sa.Column("error", sa.String(length=500), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index("ix_notification_log_incident_id", "notification_log", ["incident_id"])
-    op.create_index("ix_notification_log_service_id", "notification_log", ["service_id"])
-    op.create_index("ix_notification_log_kind_sent", "notification_log",
-                    ["service_id", "kind", sa.text("sent_at DESC")])
+    op.create_index(
+        "ix_notification_log_incident_id", "notification_log", ["incident_id"],
+    )
+    op.create_index(
+        "ix_notification_log_service_id", "notification_log", ["service_id"],
+    )
+    op.create_index(
+        "ix_notification_log_kind_sent",
+        "notification_log",
+        ["service_id", "kind", sa.text("sent_at DESC")],
+    )
+
 
 def downgrade():
+    op.drop_index("ix_notification_log_kind_sent", table_name="notification_log")
+    op.drop_index("ix_notification_log_service_id", table_name="notification_log")
+    op.drop_index("ix_notification_log_incident_id", table_name="notification_log")
     op.drop_table("notification_log")
+    op.drop_index("uq_incidents_service_open", table_name="incidents")
+    op.drop_index("ix_incidents_closed_at", table_name="incidents")
+    op.drop_index("ix_incidents_service_id", table_name="incidents")
     op.drop_table("incidents")

--- a/rest_assured/src/models/__init__.py
+++ b/rest_assured/src/models/__init__.py
@@ -1,6 +1,9 @@
 """Модели данных."""
-
+from .checks import CheckResult
+from .services import Service
+from .incidents import Incident
+from .notifications import NotificationLog
 from .checks import CheckResult
 from .services import Service
 
-__all__ = ["Service", "CheckResult"]
+__all__ = ["Service", "CheckResult", "Incident", "NotificationLog"]

--- a/rest_assured/src/models/__init__.py
+++ b/rest_assured/src/models/__init__.py
@@ -1,9 +1,7 @@
 """Модели данных."""
 from .checks import CheckResult
-from .services import Service
 from .incidents import Incident
 from .notifications import NotificationLog
-from .checks import CheckResult
 from .services import Service
 
 __all__ = ["Service", "CheckResult", "Incident", "NotificationLog"]

--- a/rest_assured/src/models/incidents.py
+++ b/rest_assured/src/models/incidents.py
@@ -1,6 +1,8 @@
 """Модель инцидента."""
 from datetime import datetime
-from sqlmodel import SQLModel, Field
+
+from sqlmodel import Field, SQLModel
+
 
 class Incident(SQLModel, table=True):
     __tablename__ = "incidents"

--- a/rest_assured/src/models/incidents.py
+++ b/rest_assured/src/models/incidents.py
@@ -1,14 +1,24 @@
 """Модель инцидента."""
-from datetime import datetime
+from datetime import datetime, timezone
 
+from sqlalchemy import Column, DateTime
 from sqlmodel import Field, SQLModel
 
 
 class Incident(SQLModel, table=True):
+    """Инцидент недоступности сервиса."""
+
     __tablename__ = "incidents"
+
     id: int | None = Field(default=None, primary_key=True)
     service_id: int = Field(foreign_key="services.id", index=True)
-    opened_at: datetime
-    closed_at: datetime | None = Field(default=None, index=True)
-    last_error: str | None = None
+    opened_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    closed_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True, index=True),
+    )
+    last_error: str | None = Field(default=None, max_length=500)
     sla_breach: bool = Field(default=False)

--- a/rest_assured/src/models/incidents.py
+++ b/rest_assured/src/models/incidents.py
@@ -1,0 +1,12 @@
+"""Модель инцидента."""
+from datetime import datetime
+from sqlmodel import SQLModel, Field
+
+class Incident(SQLModel, table=True):
+    __tablename__ = "incidents"
+    id: int | None = Field(default=None, primary_key=True)
+    service_id: int = Field(foreign_key="services.id", index=True)
+    opened_at: datetime
+    closed_at: datetime | None = Field(default=None, index=True)
+    last_error: str | None = None
+    sla_breach: bool = Field(default=False)

--- a/rest_assured/src/models/notifications.py
+++ b/rest_assured/src/models/notifications.py
@@ -1,16 +1,25 @@
 """Модель лога уведомлений."""
-from datetime import datetime
+from datetime import datetime, timezone
 
+from sqlalchemy import Column, DateTime
 from sqlmodel import Field, SQLModel
 
 
 class NotificationLog(SQLModel, table=True):
+    """Запись об отправленном уведомлении."""
+
     __tablename__ = "notification_log"
+
     id: int | None = Field(default=None, primary_key=True)
-    incident_id: int | None = Field(default=None, foreign_key="incidents.id", index=True)
+    incident_id: int | None = Field(
+        default=None, foreign_key="incidents.id", index=True,
+    )
     service_id: int = Field(foreign_key="services.id", index=True)
     kind: str = Field(max_length=50)
-    sent_at: datetime
+    sent_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
     recipients: str = Field(max_length=500)
     subject: str = Field(max_length=500)
-    error: str | None = None
+    error: str | None = Field(default=None, max_length=500)

--- a/rest_assured/src/models/notifications.py
+++ b/rest_assured/src/models/notifications.py
@@ -1,0 +1,14 @@
+"""Модель лога уведомлений."""
+from datetime import datetime
+from sqlmodel import SQLModel, Field
+
+class NotificationLog(SQLModel, table=True):
+    __tablename__ = "notification_log"
+    id: int | None = Field(default=None, primary_key=True)
+    incident_id: int | None = Field(default=None, foreign_key="incidents.id", index=True)
+    service_id: int = Field(foreign_key="services.id", index=True)
+    kind: str = Field(max_length=50)
+    sent_at: datetime
+    recipients: str = Field(max_length=500)
+    subject: str = Field(max_length=500)
+    error: str | None = None

--- a/rest_assured/src/models/notifications.py
+++ b/rest_assured/src/models/notifications.py
@@ -1,6 +1,8 @@
 """Модель лога уведомлений."""
 from datetime import datetime
-from sqlmodel import SQLModel, Field
+
+from sqlmodel import Field, SQLModel
+
 
 class NotificationLog(SQLModel, table=True):
     __tablename__ = "notification_log"

--- a/settings.toml
+++ b/settings.toml
@@ -1,7 +1,7 @@
 [app_settings]
 host = "0.0.0.0"
 port = 8000
-use_testcontainers = "True"
+use_testcontainers = true
 
 [db_settings]
 name = "test_db"


### PR DESCRIPTION
…and tests

- Add Incident and NotificationLog SQLModel models
- Create migration 002 for incidents and notification_log tables
- Add unique partial index for open incidents
- Add integration tests covering creation, uniqueness, reopen, and notification log
- Update Alembic target_metadata and test fixtures for new models

Closes #53