### PR TITLE
T4.8: GET /api/incidents with filters and JWT auth

### DIFF
--- a/rest_assured/integrational_tests/conftest.py
+++ b/rest_assured/integrational_tests/conftest.py
@@ -69,3 +69,13 @@ def router_api():
 async def router_api_admin(postgres_connection):
     client = TestClient(app)
     yield client
+
+
+@pytest.fixture
+def override_auth():
+    from rest_assured.src.auth.dependencies import get_current_user
+    from rest_assured.src.models.users import User
+
+    app.dependency_overrides[get_current_user] = lambda: User(id=1, email="admin@example.com")
+    yield
+    app.dependency_overrides.clear()

--- a/rest_assured/integrational_tests/test_incidents_endpoint.py
+++ b/rest_assured/integrational_tests/test_incidents_endpoint.py
@@ -1,0 +1,132 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from rest_assured.src.main import app
+from rest_assured.src.models.incidents import Incident
+from rest_assured.src.models.services import Service
+
+
+async def _seed_incidents(session: AsyncSession) -> list[Incident]:
+    service = Service(name="svc1", url="http://example.com", interval_ms=1000)
+    session.add(service)
+    await session.commit()
+    await session.refresh(service)
+
+    inc1 = Incident(
+        service_id=service.id,
+        opened_at=datetime.now(timezone.utc) - timedelta(hours=2),
+        closed_at=None,
+        sla_breach=False,
+        last_error="err1",
+    )
+    inc2 = Incident(
+        service_id=service.id,
+        opened_at=datetime.now(timezone.utc) - timedelta(hours=5),
+        closed_at=datetime.now(timezone.utc) - timedelta(hours=3),
+        sla_breach=False,
+        last_error="err2",
+    )
+    inc3 = Incident(
+        service_id=service.id,
+        opened_at=datetime.now(timezone.utc) - timedelta(hours=10),
+        closed_at=datetime.now(timezone.utc) - timedelta(hours=8),
+        sla_breach=True,
+        last_error="err3",
+    )
+    session.add_all([inc1, inc2, inc3])
+    await session.commit()
+    return [inc1, inc2, inc3]
+
+
+@pytest.mark.asyncio
+async def test_unauthorized(postgres_connection):
+    # Проверяем, что без JWT возвращается 401
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/incidents")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_list_all(override_auth, postgres_connection):
+    session = postgres_connection
+    await _seed_incidents(session)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/incidents")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 3
+    # Проверка сортировки: первый в списке должен иметь самое позднее opened_at
+    assert data[0]["opened_at"] > data[1]["opened_at"]
+
+
+@pytest.mark.asyncio
+async def test_filter_open(override_auth, postgres_connection):
+    session = postgres_connection
+    await _seed_incidents(session)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/incidents?open=true")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["closed_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_filter_service_and_open(override_auth, postgres_connection):
+    session = postgres_connection
+    await _seed_incidents(session)
+    # id сервиса мы знаем: это первый созданный, с id=1
+    service_id = 1
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(f"/api/incidents?service_id={service_id}&open=true")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["service_id"] == service_id
+
+
+@pytest.mark.asyncio
+async def test_filter_sla_breach(override_auth, postgres_connection):
+    session = postgres_connection
+    await _seed_incidents(session)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/incidents?sla_breach=true")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["sla_breach"] is True
+
+
+@pytest.mark.asyncio
+async def test_duration_seconds(override_auth, postgres_connection):
+    session = postgres_connection
+    await _seed_incidents(session)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/api/incidents")
+    assert response.status_code == 200
+    data = response.json()
+    for inc in data:
+        if inc["closed_at"] is None:
+            assert inc["duration_seconds"] is None
+        else:
+            expected = int(
+                (
+                    datetime.fromisoformat(inc["closed_at"])
+                    - datetime.fromisoformat(inc["opened_at"])
+                ).total_seconds()
+            )
+            assert inc["duration_seconds"] == expected

--- a/rest_assured/src/api/routers/incidents.py
+++ b/rest_assured/src/api/routers/incidents.py
@@ -1,71 +1,26 @@
-from datetime import datetime
-
-from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel
-from sqlmodel import select
+from fastapi import APIRouter, Depends, Query, Request
 
 from rest_assured.src.auth.dependencies import get_current_user
-from rest_assured.src.models.incidents import Incident
-from rest_assured.src.models.services import Service
 from rest_assured.src.models.users import User
-from rest_assured.src.repositories.database_session import get_session
+from rest_assured.src.schemas.incidents import IncidentRead
+from rest_assured.src.services.incidents import list_incidents
 
 router = APIRouter(prefix="/api/incidents", tags=["incidents"])
 
 
-class IncidentRead(BaseModel):
-    id: int
-    service_id: int
-    service_name: str
-    opened_at: datetime
-    closed_at: datetime | None
-    last_error: str | None
-    sla_breach: bool
-    duration_seconds: int | None
-
-    model_config = {"from_attributes": True}
-
-
 @router.get("", response_model=list[IncidentRead])
-async def list_incidents(
+async def list_incidents_endpoint(
+    request: Request,
     service_id: int | None = Query(None),
     open: bool | None = Query(None, description="true — только открытые, false — только закрытые"),
     sla_breach: bool | None = Query(None),
     limit: int = Query(100, ge=1, le=500),
     _: User = Depends(get_current_user),
 ) -> list[IncidentRead]:
-    session = get_session()
-    try:
-        query = select(Incident, Service.name).join(Service, Incident.service_id == Service.id)
-
-        if service_id is not None:
-            query = query.where(Incident.service_id == service_id)
-        if open is True:
-            query = query.where(Incident.closed_at.is_(None))
-        elif open is False:
-            query = query.where(Incident.closed_at.isnot(None))
-        if sla_breach is not None:
-            query = query.where(Incident.sla_breach == sla_breach)
-
-        query = query.order_by(Incident.opened_at.desc()).limit(limit)
-
-        result = await session.exec(query)
-        rows = result.all()
-
-        return [
-            IncidentRead(
-                id=inc.id,
-                service_id=inc.service_id,
-                service_name=name,
-                opened_at=inc.opened_at,
-                closed_at=inc.closed_at,
-                last_error=inc.last_error,
-                sla_breach=inc.sla_breach,
-                duration_seconds=(
-                    int((inc.closed_at - inc.opened_at).total_seconds()) if inc.closed_at else None
-                ),
-            )
-            for inc, name in rows
-        ]
-    finally:
-        await session.close()
+    return await list_incidents(
+        session_factory=request.app.state.session_factory,
+        service_id=service_id,
+        open=open,
+        sla_breach=sla_breach,
+        limit=limit,
+    )

--- a/rest_assured/src/api/routers/incidents.py
+++ b/rest_assured/src/api/routers/incidents.py
@@ -1,0 +1,71 @@
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlmodel import select
+
+from rest_assured.src.auth.dependencies import get_current_user
+from rest_assured.src.models.incidents import Incident
+from rest_assured.src.models.services import Service
+from rest_assured.src.models.users import User
+from rest_assured.src.repositories.database_session import get_session
+
+router = APIRouter(prefix="/api/incidents", tags=["incidents"])
+
+
+class IncidentRead(BaseModel):
+    id: int
+    service_id: int
+    service_name: str
+    opened_at: datetime
+    closed_at: datetime | None
+    last_error: str | None
+    sla_breach: bool
+    duration_seconds: int | None
+
+    model_config = {"from_attributes": True}
+
+
+@router.get("", response_model=list[IncidentRead])
+async def list_incidents(
+    service_id: int | None = Query(None),
+    open: bool | None = Query(None, description="true — только открытые, false — только закрытые"),
+    sla_breach: bool | None = Query(None),
+    limit: int = Query(100, ge=1, le=500),
+    _: User = Depends(get_current_user),
+) -> list[IncidentRead]:
+    session = get_session()
+    try:
+        query = select(Incident, Service.name).join(Service, Incident.service_id == Service.id)
+
+        if service_id is not None:
+            query = query.where(Incident.service_id == service_id)
+        if open is True:
+            query = query.where(Incident.closed_at.is_(None))
+        elif open is False:
+            query = query.where(Incident.closed_at.isnot(None))
+        if sla_breach is not None:
+            query = query.where(Incident.sla_breach == sla_breach)
+
+        query = query.order_by(Incident.opened_at.desc()).limit(limit)
+
+        result = await session.exec(query)
+        rows = result.all()
+
+        return [
+            IncidentRead(
+                id=inc.id,
+                service_id=inc.service_id,
+                service_name=name,
+                opened_at=inc.opened_at,
+                closed_at=inc.closed_at,
+                last_error=inc.last_error,
+                sla_breach=inc.sla_breach,
+                duration_seconds=(
+                    int((inc.closed_at - inc.opened_at).total_seconds()) if inc.closed_at else None
+                ),
+            )
+            for inc, name in rows
+        ]
+    finally:
+        await session.close()

--- a/rest_assured/src/auth/dependencies.py
+++ b/rest_assured/src/auth/dependencies.py
@@ -1,0 +1,13 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from rest_assured.src.models.users import User
+
+security = HTTPBearer()
+
+
+async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)) -> User:
+    # Временная заглушка: принимаем любой непустой токен
+    if not credentials.credentials:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    return User(id=1, email="admin@example.com")

--- a/rest_assured/src/main.py
+++ b/rest_assured/src/main.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
 
 from rest_assured.src.api.misc import misc_router
+from rest_assured.src.api.routers.incidents import router as incidents_router
 from rest_assured.src.configs.app.main import settings
 from rest_assured.src.models.checks import CheckResult
 from rest_assured.src.notifications.email import EmailSender
@@ -65,6 +66,7 @@ def create_app() -> FastAPI:
     )
 
     app.include_router(misc_router)
+    app.include_router(incidents_router)
 
     @app.get("/api/health/scheduler")
     async def health_scheduler(request: Request):

--- a/rest_assured/src/repositories/incidents.py
+++ b/rest_assured/src/repositories/incidents.py
@@ -1,0 +1,32 @@
+from collections.abc import Sequence
+from typing import Any
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from rest_assured.src.models.incidents import Incident
+from rest_assured.src.models.services import Service
+
+
+async def fetch_incidents(
+    session: AsyncSession,
+    *,
+    service_id: int | None = None,
+    open: bool | None = None,
+    sla_breach: bool | None = None,
+    limit: int = 100,
+) -> Sequence[Any]:
+    query = select(Incident, Service.name).join(Service)
+
+    if service_id is not None:
+        query = query.where(Incident.service_id == service_id)
+    if open is True:
+        query = query.where(Incident.closed_at.is_(None))
+    elif open is False:
+        query = query.where(Incident.closed_at.isnot(None))
+    if sla_breach is not None:
+        query = query.where(Incident.sla_breach == sla_breach)
+
+    query = query.order_by(Incident.opened_at.desc()).limit(limit)
+    result = await session.exec(query)
+    return result.all()

--- a/rest_assured/src/schemas/incidents.py
+++ b/rest_assured/src/schemas/incidents.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class IncidentRead(BaseModel):
+    id: int
+    service_id: int
+    service_name: str
+    opened_at: datetime
+    closed_at: datetime | None
+    last_error: str | None
+    sla_breach: bool
+    duration_seconds: int | None
+
+    model_config = {"from_attributes": True}

--- a/rest_assured/src/services/incidents.py
+++ b/rest_assured/src/services/incidents.py
@@ -12,9 +12,49 @@ from rest_assured.src.models.incidents import Incident
 from rest_assured.src.models.notifications import NotificationLog
 from rest_assured.src.models.services import Service
 from rest_assured.src.notifications.email import EmailSender
+from rest_assured.src.repositories.incidents import fetch_incidents
+from rest_assured.src.schemas.incidents import IncidentRead
 from rest_assured.src.services.metrics import compute_sla
 
 logger = logging.getLogger(__name__)
+
+
+async def list_incidents(
+    *,
+    session_factory,
+    service_id: int | None = None,
+    open: bool | None = None,
+    sla_breach: bool | None = None,
+    limit: int = 100,
+) -> list[IncidentRead]:
+    session = session_factory()
+    try:
+        rows = await fetch_incidents(
+            session,
+            service_id=service_id,
+            open=open,
+            sla_breach=sla_breach,
+            limit=limit,
+        )
+        return [
+            IncidentRead(
+                id=inc.id,
+                service_id=inc.service_id,
+                service_name=name,
+                opened_at=inc.opened_at,
+                closed_at=inc.closed_at,
+                last_error=inc.last_error,
+                sla_breach=inc.sla_breach,
+                duration_seconds=(
+                    int((inc.closed_at - inc.opened_at).total_seconds())
+                    if inc.closed_at
+                    else None
+                ),
+            )
+            for inc, name in rows
+        ]
+    finally:
+        await session.close()
 
 
 async def handle_check_result(


### PR DESCRIPTION
Closes #58

### Что сделано
- Создан эндпоинт GET /api/incidents с query-параметрами service_id, open, sla_breach и limit.
- Возвращает список `IncidentRead` с полями service_name (через JOIN) и duration_seconds.
- Защищён JWT через `get_current_user` (временная заглушка, принимает любой непустой токен).
- Подключён в `main.py`.
- Написаны 6 интеграционных тестов: 401 без авторизации, фильтры, сортировка, расчёт длительности.
- Устранена утечка сессий БД: сессия создаётся и закрывается вручную.

### DoD
- [x] Все 6 тестов зелёные.
- [x] JWT обязателен (get_current_user).
- [x] Swagger отображает query-параметры.