### PR TITLE
T4.9: add mailhog service to docker-compose.prod.yml

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -33,6 +33,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      mailhog:
+        condition: service_started
     ports:
       - "8000:8000"
     healthcheck:
@@ -60,6 +62,20 @@ services:
       start_period: 10s
     networks:
       - backend
+
+  mailhog:
+    image: mailhog/mailhog:v1.0.1
+    restart: unless-stopped
+    ports:
+      - "1025:1025"   # SMTP
+      - "8025:8025"   # Web UI
+    networks:
+      - backend
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8025/api/v2/messages"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
 volumes:
   pgdata:


### PR DESCRIPTION
Closes #59

- Добавлен сервис mailhog (mailhog/mailhog:v1.0.1) с портами 1025 и 8025.
- Настроен healthcheck.
- Сервис app теперь зависит от mailhog (condition: service_started).
- Проверена отправка письма из контейнера внутри сети docker_backend по hostname `mailhog:1025` — письмо успешно получено.