### PR TITLE
T3.2–T3.5 — MetricsService and metrics API endpoints

### DIFF
--- a/rest_assured/integrational_tests/conftest.py
+++ b/rest_assured/integrational_tests/conftest.py
@@ -13,6 +13,7 @@ from testcontainers.postgres import PostgresContainer
 from rest_assured.src.configs.app.main import settings
 from rest_assured.src.main import app
 from rest_assured.src.repositories.database_session import get_session
+from rest_assured.src.services.metrics_service import MetricsService
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -28,8 +29,9 @@ def _bootstrap_db() -> Generator[None, Any, None]:
             settings.db_settings.password = SecretStr(postgres.password)
             settings.db_settings.host = postgres.get_container_host_ip()
         run_migrations()
-        # ASGITransport не запускает lifespan, поэтому устанавливаем session_factory вручную
+        # ASGITransport не запускает lifespan, поэтому инициализируем app.state вручную
         app.state.session_factory = get_session
+        app.state.metrics_service = MetricsService(get_session, cache_ttl_seconds=0)
         yield
     finally:
         if postgres is not None:
@@ -48,6 +50,10 @@ async def postgres_connection(_bootstrap_db) -> AsyncSession:
         )
     )
     await session.commit()
+    # Тесты, поднимающие lifespan (TestClient), перезаписывают app.state.metrics_service
+    # экземпляром с включённым кэшем — сбрасываем его, чтобы сериальные id=1 не получали
+    # закэшированные нули от предыдущего теста.
+    app.state.metrics_service = MetricsService(get_session, cache_ttl_seconds=0)
     try:
         yield session
     finally:

--- a/rest_assured/integrational_tests/test_metrics_endpoint.py
+++ b/rest_assured/integrational_tests/test_metrics_endpoint.py
@@ -1,0 +1,309 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from rest_assured.src.main import app
+from rest_assured.src.models.checks import CheckResult
+from rest_assured.src.models.services import Service
+
+_BASE_URL = "http://test"
+
+
+async def _seed_service(session: AsyncSession, **kwargs) -> Service:
+    defaults = {"name": "metrics-svc", "url": "http://example.com", "interval_ms": 60000}
+    defaults.update(kwargs)
+    service = Service(**defaults)
+    session.add(service)
+    await session.commit()
+    await session.refresh(service)
+    return service
+
+
+async def _seed_checks(
+    session: AsyncSession,
+    service_id: int,
+    points: list[tuple[int, bool]],
+    *,
+    base: datetime,
+    latency_ms: int | None = None,
+) -> None:
+    for seconds, is_up in points:
+        session.add(
+            CheckResult(
+                service_id=service_id,
+                checked_at=base + timedelta(seconds=seconds),
+                is_up=is_up,
+                http_status=200 if is_up else 500,
+                latency_ms=latency_ms,
+            )
+        )
+    await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/services/{id}/metrics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_metrics_returns_404_for_missing_service(postgres_connection):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+        response = await client.get("/api/services/99999/metrics")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "service not found"
+
+
+@pytest.mark.asyncio
+async def test_metrics_zero_for_service_without_checks(postgres_connection):
+    service = await _seed_service(postgres_connection)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+        response = await client.get(f"/api/services/{service.id}/metrics")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["service_id"] == service.id
+    assert data["current_uptime_seconds"] == 0
+    assert data["sla_pct"] == 0.0
+    assert datetime.fromisoformat(data["computed_at"]) <= datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_metrics_matches_sber_example(postgres_connection):
+    """SBER reference series: 7 checks, current uptime = 10s, SLA = 50%."""
+    service = await _seed_service(postgres_connection)
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    await _seed_checks(
+        postgres_connection,
+        service.id,
+        [(0, False), (10, True), (20, True), (30, True), (40, False), (50, True), (60, True)],
+        base=base,
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+        response = await client.get(f"/api/services/{service.id}/metrics")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["current_uptime_seconds"] == 10
+    assert data["sla_pct"] == 50.0
+
+
+# ---------------------------------------------------------------------------
+# GET /api/services/summary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_summary_empty_when_no_services(postgres_connection):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+        response = await client.get("/api/services/summary")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_summary_excludes_inactive_services(postgres_connection):
+    await _seed_service(postgres_connection, name="active", is_active=True)
+    await _seed_service(postgres_connection, name="inactive", is_active=False)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+        response = await client.get("/api/services/summary")
+
+    assert response.status_code == 200
+    names = [row["name"] for row in response.json()]
+    assert names == ["active"]
+
+
+@pytest.mark.asyncio
+async def test_summary_reports_last_check_and_metrics(postgres_connection):
+    service = await _seed_service(postgres_connection)
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    await _seed_checks(
+        postgres_connection,
+        service.id,
+        [(0, True), (10, True), (20, True)],
+        base=base,
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+        response = await client.get("/api/services/summary")
+
+    assert response.status_code == 200
+    rows = response.json()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["service_id"] == service.id
+    assert row["current_uptime_seconds"] == 20
+    assert row["sla_pct"] == 100.0
+    assert row["last_check_is_up"] is True
+    assert datetime.fromisoformat(row["last_check_at"]) == base + timedelta(seconds=20)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/services/{id}/timeseries
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timeseries_returns_404_for_missing_service(postgres_connection):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+        response = await client.get(
+            "/api/services/99999/timeseries",
+            params={
+                "from": "2026-01-01T12:00:00Z",
+                "to": "2026-01-01T13:00:00Z",
+            },
+        )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "service not found"
+
+
+@pytest.mark.asyncio
+async def test_timeseries_returns_422_when_to_not_after_from(postgres_connection):
+    service = await _seed_service(postgres_connection)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+        response = await client.get(
+            f"/api/services/{service.id}/timeseries",
+            params={
+                "from": "2026-01-01T12:00:00Z",
+                "to": "2026-01-01T12:00:00Z",
+            },
+        )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_timeseries_empty_when_range_has_no_checks(postgres_connection):
+    service = await _seed_service(postgres_connection)
+    base = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    await _seed_checks(
+        postgres_connection,
+        service.id,
+        [(0, True), (10, True)],
+        base=base,
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+        response = await client.get(
+            f"/api/services/{service.id}/timeseries",
+            params={
+                "from": "2026-01-01T13:00:00Z",
+                "to": "2026-01-01T14:00:00Z",
+            },
+        )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_timeseries_groups_checks_into_buckets(postgres_connection):
+    service = await _seed_service(postgres_connection)
+    base = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    # 60 all-up checks at 1s intervals → 6 buckets of 10s, 10 checks each
+    points = [(i, True) for i in range(60)]
+    await _seed_checks(postgres_connection, service.id, points, base=base, latency_ms=100)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+        response = await client.get(
+            f"/api/services/{service.id}/timeseries",
+            params={
+                "from": "2026-01-01T12:00:00Z",
+                "to": "2026-01-01T12:01:00Z",
+                "bucket_seconds": 10,
+            },
+        )
+
+    assert response.status_code == 200
+    buckets = response.json()
+    assert len(buckets) == 6
+    expected_starts = [
+        (base + timedelta(seconds=10 * i)).isoformat().replace("+00:00", "Z") for i in range(6)
+    ]
+    assert [b["bucket_start"] for b in buckets] == expected_starts
+    for bucket in buckets:
+        assert bucket["checks_total"] == 10
+        assert bucket["checks_up"] == 10
+        assert bucket["up_ratio"] == 1.0
+        assert bucket["latency_avg_ms"] == 100.0
+        assert bucket["latency_p95_ms"] == 100.0
+
+
+@pytest.mark.asyncio
+async def test_timeseries_counts_down_checks_per_bucket(postgres_connection):
+    service = await _seed_service(postgres_connection)
+    base = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    # First bucket: 7 up + 3 down; second bucket: all up
+    bucket_a = [(i, True) for i in range(7)] + [(i, False) for i in range(7, 10)]
+    bucket_b = [(i, True) for i in range(10, 20)]
+    await _seed_checks(postgres_connection, service.id, bucket_a + bucket_b, base=base)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+        response = await client.get(
+            f"/api/services/{service.id}/timeseries",
+            params={
+                "from": "2026-01-01T12:00:00Z",
+                "to": "2026-01-01T12:00:20Z",
+                "bucket_seconds": 10,
+            },
+        )
+
+    assert response.status_code == 200
+    buckets = response.json()
+    assert len(buckets) == 2
+    assert buckets[0]["checks_total"] == 10
+    assert buckets[0]["checks_up"] == 7
+    assert buckets[0]["up_ratio"] == 0.7
+    assert buckets[1]["checks_up"] == 10
+    assert buckets[1]["up_ratio"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_timeseries_computes_p95_latency(postgres_connection):
+    service = await _seed_service(postgres_connection)
+    base = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    # 10 checks with latency_ms = 0..9
+    for i in range(10):
+        postgres_connection.add(
+            CheckResult(
+                service_id=service.id,
+                checked_at=base + timedelta(seconds=i),
+                is_up=True,
+                http_status=200,
+                latency_ms=i,
+            )
+        )
+    await postgres_connection.commit()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+        response = await client.get(
+            f"/api/services/{service.id}/timeseries",
+            params={
+                "from": "2026-01-01T12:00:00Z",
+                "to": "2026-01-01T12:00:10Z",
+                "bucket_seconds": 10,
+            },
+        )
+
+    assert response.status_code == 200
+    buckets = response.json()
+    assert len(buckets) == 1
+    bucket = buckets[0]
+    assert bucket["checks_total"] == 10
+    # percentile_cont(0.95) over [0..9] = 8.55
+    assert bucket["latency_p95_ms"] == pytest.approx(8.55)

--- a/rest_assured/src/api/dependencies.py
+++ b/rest_assured/src/api/dependencies.py
@@ -1,0 +1,14 @@
+"""Shared FastAPI dependency providers."""
+
+from typing import Annotated
+
+from fastapi import Depends, Request
+
+from rest_assured.src.services.metrics_service import MetricsService
+
+
+def get_metrics_service(request: Request) -> MetricsService:
+    return request.app.state.metrics_service
+
+
+MetricsServiceDep = Annotated[MetricsService, Depends(get_metrics_service)]

--- a/rest_assured/src/api/routers/metrics.py
+++ b/rest_assured/src/api/routers/metrics.py
@@ -1,0 +1,120 @@
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy import text
+
+from rest_assured.src.models.services import Service
+from rest_assured.src.schemas.metrics import (
+    ServiceMetricsResponse,
+    ServiceSummaryItem,
+    TimeseriesBucket,
+)
+from rest_assured.src.services.metrics_service import MetricsService
+
+router = APIRouter(prefix="/api/services", tags=["metrics"])
+
+
+def get_metrics_service(request: Request) -> MetricsService:
+    return request.app.state.metrics_service
+
+
+@router.get("/summary", response_model=list[ServiceSummaryItem])
+async def get_services_summary(
+    metrics_service: MetricsService = Depends(get_metrics_service),
+) -> list[ServiceSummaryItem]:
+    return await metrics_service.get_summary()
+
+
+@router.get("/{service_id}/metrics", response_model=ServiceMetricsResponse)
+async def get_service_metrics(
+    service_id: int,
+    request: Request,
+    metrics_service: MetricsService = Depends(get_metrics_service),
+) -> ServiceMetricsResponse:
+    session = request.app.state.session_factory()
+    try:
+        service = await session.get(Service, service_id)
+    finally:
+        await session.close()
+
+    if service is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="service not found")
+
+    uptime_seconds, sla_pct = await metrics_service.get_metrics(service_id)
+    return ServiceMetricsResponse(
+        service_id=service_id,
+        current_uptime_seconds=uptime_seconds,
+        sla_pct=sla_pct,
+        computed_at=datetime.now(timezone.utc),
+    )
+
+
+@router.get("/{service_id}/timeseries", response_model=list[TimeseriesBucket])
+async def get_service_timeseries(
+    service_id: int,
+    request: Request,
+    from_: datetime = Query(..., alias="from"),
+    to: datetime = Query(...),
+    bucket_seconds: int = Query(60, ge=10, le=3600),
+) -> list[TimeseriesBucket]:
+    if to <= from_:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="to must be greater than from",
+        )
+
+    session = request.app.state.session_factory()
+    try:
+        service = await session.get(Service, service_id)
+        if service is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="service not found")
+
+        result = await session.exec(
+            text(
+                """
+                SELECT
+                  date_trunc('second',
+                    to_timestamp(floor(extract(epoch from checked_at) / :bucket) * :bucket)
+                  ) AS bucket_start,
+                  count(*) AS checks_total,
+                  count(*) FILTER (WHERE is_up) AS checks_up,
+                  avg(latency_ms) AS latency_avg_ms,
+                  percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms) AS latency_p95_ms
+                FROM check_results
+                WHERE service_id = :service_id
+                  AND checked_at >= :from
+                  AND checked_at < :to
+                GROUP BY 1
+                ORDER BY 1 ASC
+                """
+            ),
+            params={
+                "service_id": service_id,
+                "from": from_,
+                "to": to,
+                "bucket": bucket_seconds,
+            },
+        )
+        rows = result.all()
+    finally:
+        await session.close()
+
+    buckets: list[TimeseriesBucket] = []
+    for row in rows:
+        checks_total = int(row.checks_total)
+        checks_up = int(row.checks_up)
+        buckets.append(
+            TimeseriesBucket(
+                bucket_start=row.bucket_start,
+                checks_total=checks_total,
+                checks_up=checks_up,
+                up_ratio=checks_up / checks_total,
+                latency_avg_ms=(
+                    float(row.latency_avg_ms) if row.latency_avg_ms is not None else None
+                ),
+                latency_p95_ms=(
+                    float(row.latency_p95_ms) if row.latency_p95_ms is not None else None
+                ),
+            )
+        )
+    return buckets

--- a/rest_assured/src/api/routers/metrics.py
+++ b/rest_assured/src/api/routers/metrics.py
@@ -1,26 +1,20 @@
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from sqlalchemy import text
+from fastapi import APIRouter, HTTPException, Query, status
 
-from rest_assured.src.models.services import Service
+from rest_assured.src.api.dependencies import MetricsServiceDep
 from rest_assured.src.schemas.metrics import (
     ServiceMetricsResponse,
     ServiceSummaryItem,
     TimeseriesBucket,
 )
-from rest_assured.src.services.metrics_service import MetricsService
 
 router = APIRouter(prefix="/api/services", tags=["metrics"])
 
 
-def get_metrics_service(request: Request) -> MetricsService:
-    return request.app.state.metrics_service
-
-
 @router.get("/summary", response_model=list[ServiceSummaryItem])
 async def get_services_summary(
-    metrics_service: MetricsService = Depends(get_metrics_service),
+    metrics_service: MetricsServiceDep,
 ) -> list[ServiceSummaryItem]:
     return await metrics_service.get_summary()
 
@@ -28,15 +22,9 @@ async def get_services_summary(
 @router.get("/{service_id}/metrics", response_model=ServiceMetricsResponse)
 async def get_service_metrics(
     service_id: int,
-    request: Request,
-    metrics_service: MetricsService = Depends(get_metrics_service),
+    metrics_service: MetricsServiceDep,
 ) -> ServiceMetricsResponse:
-    session = request.app.state.session_factory()
-    try:
-        service = await session.get(Service, service_id)
-    finally:
-        await session.close()
-
+    service = await metrics_service.get_service(service_id)
     if service is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="service not found")
 
@@ -52,7 +40,7 @@ async def get_service_metrics(
 @router.get("/{service_id}/timeseries", response_model=list[TimeseriesBucket])
 async def get_service_timeseries(
     service_id: int,
-    request: Request,
+    metrics_service: MetricsServiceDep,
     from_: datetime = Query(..., alias="from"),
     to: datetime = Query(...),
     bucket_seconds: int = Query(60, ge=10, le=3600),
@@ -63,58 +51,8 @@ async def get_service_timeseries(
             detail="to must be greater than from",
         )
 
-    session = request.app.state.session_factory()
-    try:
-        service = await session.get(Service, service_id)
-        if service is None:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="service not found")
+    service = await metrics_service.get_service(service_id)
+    if service is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="service not found")
 
-        result = await session.exec(
-            text(
-                """
-                SELECT
-                  date_trunc('second',
-                    to_timestamp(floor(extract(epoch from checked_at) / :bucket) * :bucket)
-                  ) AS bucket_start,
-                  count(*) AS checks_total,
-                  count(*) FILTER (WHERE is_up) AS checks_up,
-                  avg(latency_ms) AS latency_avg_ms,
-                  percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms) AS latency_p95_ms
-                FROM check_results
-                WHERE service_id = :service_id
-                  AND checked_at >= :from
-                  AND checked_at < :to
-                GROUP BY 1
-                ORDER BY 1 ASC
-                """
-            ),
-            params={
-                "service_id": service_id,
-                "from": from_,
-                "to": to,
-                "bucket": bucket_seconds,
-            },
-        )
-        rows = result.all()
-    finally:
-        await session.close()
-
-    buckets: list[TimeseriesBucket] = []
-    for row in rows:
-        checks_total = int(row.checks_total)
-        checks_up = int(row.checks_up)
-        buckets.append(
-            TimeseriesBucket(
-                bucket_start=row.bucket_start,
-                checks_total=checks_total,
-                checks_up=checks_up,
-                up_ratio=checks_up / checks_total,
-                latency_avg_ms=(
-                    float(row.latency_avg_ms) if row.latency_avg_ms is not None else None
-                ),
-                latency_p95_ms=(
-                    float(row.latency_p95_ms) if row.latency_p95_ms is not None else None
-                ),
-            )
-        )
-    return buckets
+    return await metrics_service.get_timeseries(service_id, from_, to, bucket_seconds)

--- a/rest_assured/src/configs/app/main.py
+++ b/rest_assured/src/configs/app/main.py
@@ -1,11 +1,12 @@
 import os
 
 from dynaconf import Dynaconf
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from rest_assured.src.configs.app.app import APPConfig
 from rest_assured.src.configs.app.db import DBConfig
 from rest_assured.src.configs.app.jwt import JWTConfig
+from rest_assured.src.configs.app.metrics import MetricsConfig
 from rest_assured.src.configs.app.notifications import NotificationsConfig
 from rest_assured.src.configs.app.scheduler import SchedulerSettings
 from rest_assured.src.configs.app.smtp import SmtpConfig
@@ -16,6 +17,7 @@ class Settings(BaseModel):
     app_settings: APPConfig
     jwt: JWTConfig
     scheduler: SchedulerSettings
+    metrics: MetricsConfig = Field(default_factory=MetricsConfig)
     smtp: SmtpConfig
     notifications: NotificationsConfig
 
@@ -30,6 +32,7 @@ settings = Settings(
     db_settings=env_settings["db_settings"],
     jwt=env_settings["jwt"],
     scheduler=env_settings["scheduler"],
+    metrics=env_settings.get("metrics", {}),
     smtp=env_settings["smtp"],
     notifications=env_settings["notifications"],
 )

--- a/rest_assured/src/configs/app/metrics.py
+++ b/rest_assured/src/configs/app/metrics.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class MetricsConfig(BaseModel):
+    cache_ttl_seconds: int = 5

--- a/rest_assured/src/main.py
+++ b/rest_assured/src/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from rest_assured.src.api.misc import misc_router
 from rest_assured.src.api.routers.auth import auth_router
 from rest_assured.src.api.routers.incidents import router as incidents_router
+from rest_assured.src.api.routers.metrics import router as metrics_router
 from rest_assured.src.api.routers.scheduler import router as scheduler_router
 from rest_assured.src.api.routers.services import router as services_router
 from rest_assured.src.configs.app.main import settings
@@ -16,6 +17,7 @@ from rest_assured.src.repositories.database_session import get_session
 from rest_assured.src.scheduler.listener import ServiceChangeListener
 from rest_assured.src.scheduler.runner import SchedulerRunner
 from rest_assured.src.services.incidents import handle_check_result
+from rest_assured.src.services.metrics_service import MetricsService
 from rest_assured.src.utils.version import get_app_version
 
 
@@ -31,7 +33,10 @@ def create_app() -> FastAPI:
         email_sender = EmailSender(settings.smtp)
         # session_factory для передачи в callback (берём из проекта)
         session_factory = get_session
-        metrics_service = None  # пока не реализован
+        metrics_service = MetricsService(
+            session_factory,
+            cache_ttl_seconds=settings.metrics.cache_ttl_seconds,
+        )
 
         # Сохраняем в state, чтобы другие компоненты могли использовать
         app.state.email_sender = email_sender
@@ -71,6 +76,7 @@ def create_app() -> FastAPI:
     app.include_router(misc_router)
     app.include_router(auth_router)
     app.include_router(incidents_router)
+    app.include_router(metrics_router)
     app.include_router(scheduler_router)
     app.include_router(services_router)
 

--- a/rest_assured/src/repositories/metrics.py
+++ b/rest_assured/src/repositories/metrics.py
@@ -1,0 +1,86 @@
+from collections.abc import Sequence
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import Row, and_, func, text
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from rest_assured.src.models.checks import CheckResult
+from rest_assured.src.models.services import Service
+
+
+async def fetch_checks_for_service(session: AsyncSession, service_id: int) -> Sequence[CheckResult]:
+    result = await session.exec(
+        select(CheckResult)
+        .where(CheckResult.service_id == service_id)
+        .order_by(col(CheckResult.checked_at).asc())
+    )
+    return result.all()
+
+
+async def fetch_active_services_with_last_check(
+    session: AsyncSession,
+) -> Sequence[tuple[Service, datetime | None, bool | None]]:
+    last_checks = select(
+        col(CheckResult.service_id).label("service_id"),
+        col(CheckResult.checked_at).label("checked_at"),
+        col(CheckResult.is_up).label("is_up"),
+        func.row_number()
+        .over(
+            partition_by=col(CheckResult.service_id),
+            order_by=col(CheckResult.checked_at).desc(),
+        )
+        .label("rn"),
+    ).subquery()
+    result = await session.exec(
+        select(Service, last_checks.c.checked_at, last_checks.c.is_up)
+        .outerjoin(
+            last_checks,
+            and_(
+                last_checks.c.service_id == Service.id,
+                last_checks.c.rn == 1,
+            ),
+        )
+        .where(col(Service.is_active).is_(True))
+        .order_by(col(Service.id).asc())
+    )
+    return result.all()
+
+
+async def fetch_timeseries_buckets(
+    session: AsyncSession,
+    service_id: int,
+    from_: datetime,
+    to: datetime,
+    bucket_seconds: int,
+) -> Sequence[Row[Any]]:
+    # session.execute() intentional here: raw SQL with aggregate aliases,
+    # no ORM model to return.
+    result = await session.execute(  # type: ignore[call-overload]
+        text(
+            """
+            SELECT
+              date_trunc('second',
+                to_timestamp(floor(extract(epoch from checked_at) / :bucket) * :bucket)
+              ) AS bucket_start,
+              count(*) AS checks_total,
+              count(*) FILTER (WHERE is_up) AS checks_up,
+              avg(latency_ms) AS latency_avg_ms,
+              percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms) AS latency_p95_ms
+            FROM check_results
+            WHERE service_id = :service_id
+              AND checked_at >= :from
+              AND checked_at < :to
+            GROUP BY 1
+            ORDER BY 1 ASC
+            """
+        ),
+        {
+            "service_id": service_id,
+            "from": from_,
+            "to": to,
+            "bucket": bucket_seconds,
+        },
+    )
+    return result.all()

--- a/rest_assured/src/schemas/metrics.py
+++ b/rest_assured/src/schemas/metrics.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class ServiceMetricsResponse(BaseModel):
+    service_id: int
+    current_uptime_seconds: int
+    sla_pct: float
+    computed_at: datetime
+
+
+class ServiceSummaryItem(BaseModel):
+    service_id: int
+    name: str
+    url: str
+    is_active: bool
+    current_uptime_seconds: int
+    sla_pct: float
+    last_check_at: datetime | None
+    last_check_is_up: bool | None
+
+
+class TimeseriesBucket(BaseModel):
+    bucket_start: datetime
+    checks_total: int
+    checks_up: int
+    up_ratio: float
+    latency_avg_ms: float | None
+    latency_p95_ms: float | None

--- a/rest_assured/src/services/metrics_service.py
+++ b/rest_assured/src/services/metrics_service.py
@@ -1,0 +1,118 @@
+import asyncio
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import cast
+
+from sqlalchemy import and_, func
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from rest_assured.src.models.checks import CheckResult as CheckResultModel
+from rest_assured.src.models.services import Service
+from rest_assured.src.schemas.metrics import ServiceSummaryItem
+from rest_assured.src.services.metrics import (
+    CheckResult as MetricsCheckResult,
+)
+from rest_assured.src.services.metrics import (
+    compute_current_uptime,
+    compute_sla,
+)
+
+
+class MetricsService:
+    def __init__(
+        self,
+        session_factory: Callable[[], AsyncSession],
+        cache_ttl_seconds: int = 5,
+    ) -> None:
+        self._session_factory = session_factory
+        self._cache_ttl_seconds = cache_ttl_seconds
+        self._cache: dict[int, tuple[int, float, datetime]] = {}
+        self._lock = asyncio.Lock()
+
+    async def get_metrics(self, service_id: int) -> tuple[int, float]:
+        cached = self._cache.get(service_id)
+        if cached is not None and self._is_fresh(cached[2]):
+            return cached[0], cached[1]
+
+        async with self._lock:
+            cached = self._cache.get(service_id)
+            if cached is not None and self._is_fresh(cached[2]):
+                return cached[0], cached[1]
+
+            session = self._session_factory()
+            try:
+                result = await session.exec(
+                    select(CheckResultModel)
+                    .where(CheckResultModel.service_id == service_id)
+                    .order_by(col(CheckResultModel.checked_at).asc())
+                )
+                checks = cast(list[MetricsCheckResult], list(result.all()))
+            finally:
+                await session.close()
+
+            uptime_seconds = compute_current_uptime(checks)
+            sla_pct = round(compute_sla(checks) * 100.0, 2)
+            self._cache[service_id] = (uptime_seconds, sla_pct, self._now())
+            return uptime_seconds, sla_pct
+
+    async def get_summary(self) -> list[ServiceSummaryItem]:
+        last_checks = (
+            select(
+                col(CheckResultModel.service_id).label("service_id"),
+                col(CheckResultModel.checked_at).label("checked_at"),
+                col(CheckResultModel.is_up).label("is_up"),
+                func.row_number()
+                .over(
+                    partition_by=col(CheckResultModel.service_id),
+                    order_by=col(CheckResultModel.checked_at).desc(),
+                )
+                .label("rn"),
+            )
+            .subquery()
+        )
+
+        session = self._session_factory()
+        try:
+            result = await session.exec(
+                select(Service, last_checks.c.checked_at, last_checks.c.is_up)
+                .outerjoin(
+                    last_checks,
+                    and_(
+                        last_checks.c.service_id == Service.id,
+                        last_checks.c.rn == 1,
+                    ),
+                )
+                .where(col(Service.is_active).is_(True))
+                .order_by(col(Service.id).asc())
+            )
+            rows = result.all()
+        finally:
+            await session.close()
+
+        items: list[ServiceSummaryItem] = []
+        for service, last_check_at, last_check_is_up in rows:
+            if service.id is None:
+                continue
+            uptime_seconds, sla_pct = await self.get_metrics(service.id)
+            items.append(
+                ServiceSummaryItem(
+                    service_id=service.id,
+                    name=service.name,
+                    url=service.url,
+                    is_active=service.is_active,
+                    current_uptime_seconds=uptime_seconds,
+                    sla_pct=round(sla_pct, 2),
+                    last_check_at=last_check_at,
+                    last_check_is_up=last_check_is_up,
+                )
+            )
+        return items
+
+    def _is_fresh(self, cached_at: datetime) -> bool:
+        age = (self._now() - cached_at).total_seconds()
+        return age < self._cache_ttl_seconds
+
+    @staticmethod
+    def _now() -> datetime:
+        return datetime.now(timezone.utc)

--- a/rest_assured/src/services/metrics_service.py
+++ b/rest_assured/src/services/metrics_service.py
@@ -3,13 +3,15 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import cast
 
-from sqlalchemy import and_, func
-from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from rest_assured.src.models.checks import CheckResult as CheckResultModel
 from rest_assured.src.models.services import Service
-from rest_assured.src.schemas.metrics import ServiceSummaryItem
+from rest_assured.src.repositories.metrics import (
+    fetch_active_services_with_last_check,
+    fetch_checks_for_service,
+    fetch_timeseries_buckets,
+)
+from rest_assured.src.schemas.metrics import ServiceSummaryItem, TimeseriesBucket
 from rest_assured.src.services.metrics import (
     CheckResult as MetricsCheckResult,
 )
@@ -40,55 +42,24 @@ class MetricsService:
             if cached is not None and self._is_fresh(cached[2]):
                 return cached[0], cached[1]
 
-            session = self._session_factory()
-            try:
-                result = await session.exec(
-                    select(CheckResultModel)
-                    .where(CheckResultModel.service_id == service_id)
-                    .order_by(col(CheckResultModel.checked_at).asc())
+            async with self._session_scope() as session:
+                checks = cast(
+                    list[MetricsCheckResult],
+                    list(await fetch_checks_for_service(session, service_id)),
                 )
-                checks = cast(list[MetricsCheckResult], list(result.all()))
-            finally:
-                await session.close()
 
             uptime_seconds = compute_current_uptime(checks)
             sla_pct = round(compute_sla(checks) * 100.0, 2)
             self._cache[service_id] = (uptime_seconds, sla_pct, self._now())
             return uptime_seconds, sla_pct
 
-    async def get_summary(self) -> list[ServiceSummaryItem]:
-        last_checks = (
-            select(
-                col(CheckResultModel.service_id).label("service_id"),
-                col(CheckResultModel.checked_at).label("checked_at"),
-                col(CheckResultModel.is_up).label("is_up"),
-                func.row_number()
-                .over(
-                    partition_by=col(CheckResultModel.service_id),
-                    order_by=col(CheckResultModel.checked_at).desc(),
-                )
-                .label("rn"),
-            )
-            .subquery()
-        )
+    async def get_service(self, service_id: int) -> Service | None:
+        async with self._session_scope() as session:
+            return await session.get(Service, service_id)
 
-        session = self._session_factory()
-        try:
-            result = await session.exec(
-                select(Service, last_checks.c.checked_at, last_checks.c.is_up)
-                .outerjoin(
-                    last_checks,
-                    and_(
-                        last_checks.c.service_id == Service.id,
-                        last_checks.c.rn == 1,
-                    ),
-                )
-                .where(col(Service.is_active).is_(True))
-                .order_by(col(Service.id).asc())
-            )
-            rows = result.all()
-        finally:
-            await session.close()
+    async def get_summary(self) -> list[ServiceSummaryItem]:
+        async with self._session_scope() as session:
+            rows = await fetch_active_services_with_last_check(session)
 
         items: list[ServiceSummaryItem] = []
         for service, last_check_at, last_check_is_up in rows:
@@ -109,6 +80,39 @@ class MetricsService:
             )
         return items
 
+    async def get_timeseries(
+        self,
+        service_id: int,
+        from_: datetime,
+        to: datetime,
+        bucket_seconds: int,
+    ) -> list[TimeseriesBucket]:
+        async with self._session_scope() as session:
+            rows = await fetch_timeseries_buckets(session, service_id, from_, to, bucket_seconds)
+
+        buckets: list[TimeseriesBucket] = []
+        for row in rows:
+            checks_total = int(row.checks_total)
+            checks_up = int(row.checks_up)
+            buckets.append(
+                TimeseriesBucket(
+                    bucket_start=row.bucket_start,
+                    checks_total=checks_total,
+                    checks_up=checks_up,
+                    up_ratio=checks_up / checks_total,
+                    latency_avg_ms=(
+                        float(row.latency_avg_ms) if row.latency_avg_ms is not None else None
+                    ),
+                    latency_p95_ms=(
+                        float(row.latency_p95_ms) if row.latency_p95_ms is not None else None
+                    ),
+                )
+            )
+        return buckets
+
+    def _session_scope(self) -> "_SessionScope":
+        return _SessionScope(self._session_factory())
+
     def _is_fresh(self, cached_at: datetime) -> bool:
         age = (self._now() - cached_at).total_seconds()
         return age < self._cache_ttl_seconds
@@ -116,3 +120,16 @@ class MetricsService:
     @staticmethod
     def _now() -> datetime:
         return datetime.now(timezone.utc)
+
+
+class _SessionScope:
+    """Async context manager that closes the session on exit."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def __aenter__(self) -> AsyncSession:
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self._session.close()

--- a/rest_assured/tests/api/test_metrics_endpoint.py
+++ b/rest_assured/tests/api/test_metrics_endpoint.py
@@ -1,37 +1,31 @@
 from datetime import datetime, timezone
-from typing import Any
 
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
+from rest_assured.src.api.dependencies import get_metrics_service
 from rest_assured.src.api.routers.metrics import router
 from rest_assured.src.models.services import Service
 
 
 class FakeMetricsService:
+    def __init__(self, services: dict[int, Service]) -> None:
+        self.services = services
+
+    async def get_service(self, service_id: int) -> Service | None:
+        return self.services.get(service_id)
+
     async def get_metrics(self, service_id: int) -> tuple[int, float]:
         if service_id == 3:
             return 0, 0.0
         return 42, 99.5
 
 
-class FakeSession:
-    def __init__(self, services: dict[int, Service]) -> None:
-        self.services = services
-
-    async def get(self, model: Any, item_id: int) -> Service | None:
-        return self.services.get(item_id)
-
-    async def close(self) -> None:
-        pass
-
-
 def make_app(services: dict[int, Service]) -> FastAPI:
     app = FastAPI()
-    app.state.metrics_service = FakeMetricsService()
-    app.state.session_factory = lambda: FakeSession(services)
     app.include_router(router)
+    app.dependency_overrides[get_metrics_service] = lambda: FakeMetricsService(services)
     return app
 
 

--- a/rest_assured/tests/api/test_metrics_endpoint.py
+++ b/rest_assured/tests/api/test_metrics_endpoint.py
@@ -1,0 +1,84 @@
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from rest_assured.src.api.routers.metrics import router
+from rest_assured.src.models.services import Service
+
+
+class FakeMetricsService:
+    async def get_metrics(self, service_id: int) -> tuple[int, float]:
+        if service_id == 3:
+            return 0, 0.0
+        return 42, 99.5
+
+
+class FakeSession:
+    def __init__(self, services: dict[int, Service]) -> None:
+        self.services = services
+
+    async def get(self, model: Any, item_id: int) -> Service | None:
+        return self.services.get(item_id)
+
+    async def close(self) -> None:
+        pass
+
+
+def make_app(services: dict[int, Service]) -> FastAPI:
+    app = FastAPI()
+    app.state.metrics_service = FakeMetricsService()
+    app.state.session_factory = lambda: FakeSession(services)
+    app.include_router(router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_get_service_metrics_returns_200() -> None:
+    app = make_app({1: Service(id=1, name="svc", url="http://example.com")})
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/api/services/1/metrics")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["service_id"] == 1
+    assert data["current_uptime_seconds"] == 42
+    assert data["sla_pct"] == 99.5
+    assert datetime.fromisoformat(data["computed_at"]) <= datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_get_service_metrics_returns_404_for_missing_service() -> None:
+    app = make_app({})
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/api/services/404/metrics")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "service not found"
+
+
+@pytest.mark.asyncio
+async def test_get_service_metrics_service_without_checks_returns_zeroes() -> None:
+    app = make_app({3: Service(id=3, name="empty", url="http://example.com")})
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/api/services/3/metrics")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["current_uptime_seconds"] == 0
+    assert data["sla_pct"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_get_service_metrics_without_authorization_header_returns_200() -> None:
+    app = make_app({1: Service(id=1, name="svc", url="http://example.com")})
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/api/services/1/metrics")
+
+    assert response.status_code == 200

--- a/rest_assured/tests/api/test_summary_endpoint.py
+++ b/rest_assured/tests/api/test_summary_endpoint.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
+from rest_assured.src.api.dependencies import get_metrics_service
 from rest_assured.src.api.routers.metrics import router
 from rest_assured.src.schemas.metrics import ServiceSummaryItem
 
@@ -18,8 +19,8 @@ class FakeMetricsService:
 
 def make_app(rows: list[ServiceSummaryItem]) -> FastAPI:
     app = FastAPI()
-    app.state.metrics_service = FakeMetricsService(rows)
     app.include_router(router)
+    app.dependency_overrides[get_metrics_service] = lambda: FakeMetricsService(rows)
     return app
 
 

--- a/rest_assured/tests/api/test_summary_endpoint.py
+++ b/rest_assured/tests/api/test_summary_endpoint.py
@@ -1,0 +1,89 @@
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from rest_assured.src.api.routers.metrics import router
+from rest_assured.src.schemas.metrics import ServiceSummaryItem
+
+
+class FakeMetricsService:
+    def __init__(self, rows: list[ServiceSummaryItem]) -> None:
+        self.rows = rows
+
+    async def get_summary(self) -> list[ServiceSummaryItem]:
+        return self.rows
+
+
+def make_app(rows: list[ServiceSummaryItem]) -> FastAPI:
+    app = FastAPI()
+    app.state.metrics_service = FakeMetricsService(rows)
+    app.include_router(router)
+    return app
+
+
+def item(
+    service_id: int,
+    *,
+    is_active: bool = True,
+    last_check_at: datetime | None = None,
+    last_check_is_up: bool | None = None,
+) -> ServiceSummaryItem:
+    return ServiceSummaryItem(
+        service_id=service_id,
+        name=f"svc{service_id}",
+        url=f"http://example.com/{service_id}",
+        is_active=is_active,
+        current_uptime_seconds=service_id * 10,
+        sla_pct=90.0 + service_id,
+        last_check_at=last_check_at,
+        last_check_is_up=last_check_is_up,
+    )
+
+
+@pytest.mark.asyncio
+async def test_summary_empty_services_returns_empty_list() -> None:
+    app = make_app([])
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/api/services/summary")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_summary_returns_three_services_in_order() -> None:
+    app = make_app([item(1), item(2), item(3)])
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/api/services/summary")
+
+    assert response.status_code == 200
+    assert [row["service_id"] for row in response.json()] == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_summary_does_not_include_inactive_service() -> None:
+    app = make_app([item(1), item(3)])
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/api/services/summary")
+
+    assert response.status_code == 200
+    assert [row["service_id"] for row in response.json()] == [1, 3]
+
+
+@pytest.mark.asyncio
+async def test_summary_returns_last_check_fields() -> None:
+    last_check_at = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    app = make_app([item(1, last_check_at=last_check_at, last_check_is_up=True)])
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/api/services/summary")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data[0]["last_check_at"] == "2026-01-01T12:00:00Z"
+    assert data[0]["last_check_is_up"] is True

--- a/rest_assured/tests/api/test_timeseries.py
+++ b/rest_assured/tests/api/test_timeseries.py
@@ -1,0 +1,179 @@
+from collections import namedtuple
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from rest_assured.src.api.routers.metrics import router
+from rest_assured.src.models.services import Service
+
+TimeseriesRow = namedtuple(
+    "TimeseriesRow",
+    ["bucket_start", "checks_total", "checks_up", "latency_avg_ms", "latency_p95_ms"],
+)
+
+
+class FakeResult:
+    def __init__(self, rows: list[TimeseriesRow]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[TimeseriesRow]:
+        return self._rows
+
+
+class FakeSession:
+    def __init__(self, service: Service | None, checks: list[dict[str, Any]]) -> None:
+        self.service = service
+        self.checks = checks
+
+    async def get(self, model: Any, item_id: int) -> Service | None:
+        return self.service
+
+    async def exec(self, statement: Any, params: dict[str, Any]) -> FakeResult:
+        bucket = params["bucket"]
+        from_ = params["from"]
+        to = params["to"]
+        grouped: dict[datetime, list[dict[str, Any]]] = {}
+        for check in self.checks:
+            checked_at = check["checked_at"]
+            if checked_at < from_ or checked_at >= to:
+                continue
+            epoch = int(checked_at.timestamp())
+            bucket_start = datetime.fromtimestamp((epoch // bucket) * bucket, tz=timezone.utc)
+            grouped.setdefault(bucket_start, []).append(check)
+
+        rows = []
+        for bucket_start in sorted(grouped):
+            bucket_checks = grouped[bucket_start]
+            latencies = [check["latency_ms"] for check in bucket_checks]
+            rows.append(
+                TimeseriesRow(
+                    bucket_start=bucket_start,
+                    checks_total=len(bucket_checks),
+                    checks_up=sum(1 for check in bucket_checks if check["is_up"]),
+                    latency_avg_ms=sum(latencies) / len(latencies),
+                    latency_p95_ms=percentile_cont(latencies, 0.95),
+                )
+            )
+        return FakeResult(rows)
+
+    async def close(self) -> None:
+        pass
+
+
+def percentile_cont(values: list[int], percentile: float) -> float:
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return float(ordered[0])
+    rank = (len(ordered) - 1) * percentile
+    lower_index = int(rank)
+    upper_index = min(lower_index + 1, len(ordered) - 1)
+    fraction = rank - lower_index
+    return ordered[lower_index] + (ordered[upper_index] - ordered[lower_index]) * fraction
+
+
+def make_app(service: Service | None, checks: list[dict[str, Any]]) -> FastAPI:
+    app = FastAPI()
+    app.state.session_factory = lambda: FakeSession(service, checks)
+    app.include_router(router)
+    return app
+
+
+def make_checks(count: int = 60) -> list[dict[str, Any]]:
+    base = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    return [
+        {
+            "checked_at": base + timedelta(seconds=i),
+            "is_up": i % 3 != 0,
+            "latency_ms": i % 10,
+        }
+        for i in range(count)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_timeseries_sixty_checks_by_ten_seconds_returns_six_buckets() -> None:
+    app = make_app(Service(id=1, name="svc", url="http://example.com"), make_checks())
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            "/api/services/1/timeseries",
+            params={
+                "from": "2026-01-01T12:00:00Z",
+                "to": "2026-01-01T12:01:00Z",
+                "bucket_seconds": 10,
+            },
+        )
+
+    assert response.status_code == 200
+    assert len(response.json()) == 6
+
+
+@pytest.mark.asyncio
+async def test_timeseries_to_less_than_or_equal_from_returns_422() -> None:
+    app = make_app(Service(id=1, name="svc", url="http://example.com"), [])
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            "/api/services/1/timeseries",
+            params={
+                "from": "2026-01-01T12:00:00Z",
+                "to": "2026-01-01T12:00:00Z",
+            },
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_timeseries_missing_service_returns_404() -> None:
+    app = make_app(None, [])
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            "/api/services/404/timeseries",
+            params={
+                "from": "2026-01-01T12:00:00Z",
+                "to": "2026-01-01T12:01:00Z",
+            },
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "service not found"
+
+
+@pytest.mark.asyncio
+async def test_timeseries_empty_range_returns_empty_list() -> None:
+    app = make_app(Service(id=1, name="svc", url="http://example.com"), make_checks())
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            "/api/services/1/timeseries",
+            params={
+                "from": "2026-01-01T13:00:00Z",
+                "to": "2026-01-01T14:00:00Z",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_timeseries_returns_p95_latency() -> None:
+    app = make_app(Service(id=1, name="svc", url="http://example.com"), make_checks(10))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            "/api/services/1/timeseries",
+            params={
+                "from": "2026-01-01T12:00:00Z",
+                "to": "2026-01-01T12:00:10Z",
+                "bucket_seconds": 10,
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()[0]["latency_p95_ms"] == pytest.approx(8.55)

--- a/rest_assured/tests/api/test_timeseries.py
+++ b/rest_assured/tests/api/test_timeseries.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -6,61 +5,10 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
+from rest_assured.src.api.dependencies import get_metrics_service
 from rest_assured.src.api.routers.metrics import router
 from rest_assured.src.models.services import Service
-
-TimeseriesRow = namedtuple(
-    "TimeseriesRow",
-    ["bucket_start", "checks_total", "checks_up", "latency_avg_ms", "latency_p95_ms"],
-)
-
-
-class FakeResult:
-    def __init__(self, rows: list[TimeseriesRow]) -> None:
-        self._rows = rows
-
-    def all(self) -> list[TimeseriesRow]:
-        return self._rows
-
-
-class FakeSession:
-    def __init__(self, service: Service | None, checks: list[dict[str, Any]]) -> None:
-        self.service = service
-        self.checks = checks
-
-    async def get(self, model: Any, item_id: int) -> Service | None:
-        return self.service
-
-    async def exec(self, statement: Any, params: dict[str, Any]) -> FakeResult:
-        bucket = params["bucket"]
-        from_ = params["from"]
-        to = params["to"]
-        grouped: dict[datetime, list[dict[str, Any]]] = {}
-        for check in self.checks:
-            checked_at = check["checked_at"]
-            if checked_at < from_ or checked_at >= to:
-                continue
-            epoch = int(checked_at.timestamp())
-            bucket_start = datetime.fromtimestamp((epoch // bucket) * bucket, tz=timezone.utc)
-            grouped.setdefault(bucket_start, []).append(check)
-
-        rows = []
-        for bucket_start in sorted(grouped):
-            bucket_checks = grouped[bucket_start]
-            latencies = [check["latency_ms"] for check in bucket_checks]
-            rows.append(
-                TimeseriesRow(
-                    bucket_start=bucket_start,
-                    checks_total=len(bucket_checks),
-                    checks_up=sum(1 for check in bucket_checks if check["is_up"]),
-                    latency_avg_ms=sum(latencies) / len(latencies),
-                    latency_p95_ms=percentile_cont(latencies, 0.95),
-                )
-            )
-        return FakeResult(rows)
-
-    async def close(self) -> None:
-        pass
+from rest_assured.src.schemas.metrics import TimeseriesBucket
 
 
 def percentile_cont(values: list[int], percentile: float) -> float:
@@ -74,10 +22,64 @@ def percentile_cont(values: list[int], percentile: float) -> float:
     return ordered[lower_index] + (ordered[upper_index] - ordered[lower_index]) * fraction
 
 
+def aggregate_buckets(
+    checks: list[dict[str, Any]],
+    from_: datetime,
+    to: datetime,
+    bucket_seconds: int,
+) -> list[TimeseriesBucket]:
+    grouped: dict[datetime, list[dict[str, Any]]] = {}
+    for check in checks:
+        checked_at = check["checked_at"]
+        if checked_at < from_ or checked_at >= to:
+            continue
+        epoch = int(checked_at.timestamp())
+        bucket_start = datetime.fromtimestamp(
+            (epoch // bucket_seconds) * bucket_seconds, tz=timezone.utc
+        )
+        grouped.setdefault(bucket_start, []).append(check)
+
+    buckets: list[TimeseriesBucket] = []
+    for bucket_start in sorted(grouped):
+        bucket_checks = grouped[bucket_start]
+        latencies = [check["latency_ms"] for check in bucket_checks]
+        checks_total = len(bucket_checks)
+        checks_up = sum(1 for check in bucket_checks if check["is_up"])
+        buckets.append(
+            TimeseriesBucket(
+                bucket_start=bucket_start,
+                checks_total=checks_total,
+                checks_up=checks_up,
+                up_ratio=checks_up / checks_total,
+                latency_avg_ms=sum(latencies) / len(latencies),
+                latency_p95_ms=percentile_cont(latencies, 0.95),
+            )
+        )
+    return buckets
+
+
+class FakeMetricsService:
+    def __init__(self, service: Service | None, checks: list[dict[str, Any]]) -> None:
+        self.service = service
+        self.checks = checks
+
+    async def get_service(self, service_id: int) -> Service | None:
+        return self.service
+
+    async def get_timeseries(
+        self,
+        service_id: int,
+        from_: datetime,
+        to: datetime,
+        bucket_seconds: int,
+    ) -> list[TimeseriesBucket]:
+        return aggregate_buckets(self.checks, from_, to, bucket_seconds)
+
+
 def make_app(service: Service | None, checks: list[dict[str, Any]]) -> FastAPI:
     app = FastAPI()
-    app.state.session_factory = lambda: FakeSession(service, checks)
     app.include_router(router)
+    app.dependency_overrides[get_metrics_service] = lambda: FakeMetricsService(service, checks)
     return app
 
 

--- a/rest_assured/tests/services/test_metrics_service.py
+++ b/rest_assured/tests/services/test_metrics_service.py
@@ -1,0 +1,116 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from rest_assured.src.models.services import Service
+from rest_assured.src.services.metrics_service import MetricsService
+
+
+class FakeResult:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+
+class FakeSession:
+    def __init__(self, rows: list[Any]) -> None:
+        self.rows = rows
+        self.exec_count = 0
+        self.closed = False
+
+    async def exec(self, statement: Any, **kwargs: Any) -> FakeResult:
+        self.exec_count += 1
+        return FakeResult(self.rows)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def make_check(base: datetime, seconds: int, is_up: bool) -> SimpleNamespace:
+    return SimpleNamespace(checked_at=base + timedelta(seconds=seconds), is_up=is_up)
+
+
+@pytest.mark.asyncio
+async def test_get_metrics_computes_uptime_and_sla() -> None:
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    session = FakeSession(
+        [
+            make_check(base, 0, False),
+            make_check(base, 10, True),
+            make_check(base, 20, True),
+            make_check(base, 30, True),
+            make_check(base, 40, False),
+            make_check(base, 50, True),
+            make_check(base, 60, True),
+        ]
+    )
+    service = MetricsService(lambda: session)
+
+    uptime_seconds, sla_pct = await service.get_metrics(1)
+
+    assert uptime_seconds == 10
+    assert sla_pct == 50.0
+
+
+@pytest.mark.asyncio
+async def test_get_metrics_cache_hit_does_not_query_db_twice() -> None:
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    session = FakeSession([make_check(base, 0, True), make_check(base, 10, True)])
+    service = MetricsService(lambda: session, cache_ttl_seconds=5)
+
+    assert await service.get_metrics(1) == (10, 100.0)
+    assert await service.get_metrics(1) == (10, 100.0)
+
+    assert session.exec_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_metrics_cache_expire_invalidates_cache() -> None:
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    sessions = [
+        FakeSession([make_check(base, 0, True), make_check(base, 10, True)]),
+        FakeSession(
+            [
+                make_check(base, 0, True),
+                make_check(base, 10, False),
+                make_check(base, 20, True),
+            ]
+        ),
+    ]
+    service = MetricsService(lambda: sessions.pop(0), cache_ttl_seconds=5)
+
+    assert await service.get_metrics(1) == (10, 100.0)
+    service._cache[1] = (10, 100.0, datetime(2020, 1, 1, tzinfo=timezone.utc))
+
+    assert await service.get_metrics(1) == (0, 0.0)
+    assert not sessions
+
+
+@pytest.mark.asyncio
+async def test_get_summary_for_multiple_services() -> None:
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    services = [
+        Service(id=1, name="svc1", url="http://example.com/1", is_active=True),
+        Service(id=2, name="svc2", url="http://example.com/2", is_active=True),
+    ]
+    sessions = [
+        FakeSession([(services[0], base + timedelta(seconds=20), True), (services[1], None, None)]),
+        FakeSession([make_check(base, 0, True), make_check(base, 20, True)]),
+        FakeSession([]),
+    ]
+    service = MetricsService(lambda: sessions.pop(0))
+
+    summary = await service.get_summary()
+
+    assert [item.service_id for item in summary] == [1, 2]
+    assert summary[0].current_uptime_seconds == 20
+    assert summary[0].sla_pct == 100.0
+    assert summary[0].last_check_at == base + timedelta(seconds=20)
+    assert summary[0].last_check_is_up is True
+    assert summary[1].current_uptime_seconds == 0
+    assert summary[1].sla_pct == 0.0
+    assert not sessions

--- a/settings.toml
+++ b/settings.toml
@@ -14,6 +14,9 @@ port = 5432
 poll_interval_seconds = 5
 default_timeout_ms = 5000
 
+[metrics]
+cache_ttl_seconds = 5
+
 [smtp]
 host = "mailhog"
 port = 1025

--- a/settings.toml.example
+++ b/settings.toml.example
@@ -14,6 +14,9 @@ port = 5432
 poll_interval_seconds = 5
 default_timeout_ms = 5000
 
+[metrics]
+cache_ttl_seconds = 5
+
 [smtp]
 host = "mailhog"
 port = 1025


### PR DESCRIPTION
Дополнительно:
- реализован MetricsService с TTL-кешем
- добавлены GET /api/services/{service_id}/metrics
- добавлен GET /api/services/summary
- добавлен GET /api/services/{service_id}/timeseries
- добавлены тесты для service/api/timeseries

Проверка:
- make lint — passed
- make utest — passed
- poetry run mypy rest_assured/src/services/metrics_service.py rest_assured/src/api/routers/metrics.py rest_assured/src/schemas/metrics.py rest_assured/src/configs/app/metrics.py — passed

Примечание:
- make type сейчас падает на существующих ошибках вне metrics-модуля: alembic/incidents/scheduler/dynaconf.